### PR TITLE
Add benchmark throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,22 +170,21 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fab20f5802e0b897093184f5dc5d23447fa715604f238dc798f6da188b230019"
+checksum = "1a2f0b89afd851ac3372f22144e66157058999ffe695a337711d5511acb91504"
 dependencies = [
  "clap",
  "condtype",
  "divan-macros",
- "linkme",
  "regex-lite",
 ]
 
 [[package]]
 name = "divan-macros"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5d6354551e0b5c451a948814fc47fe745a14eac7835c087d60162661019db4"
+checksum = "016a705a288faf1e8d45113e54ffcc7b566e1572ff829b8455546362b0c902f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -217,26 +216,6 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "linkme"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ed2ee9464ff9707af8e9ad834cffa4802f072caad90639c583dd3c62e6e608"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "linux-raw-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ adler = "1.0.2"
 blake2 = { version = "0.10.6" }
 blake3 = { version = "1.5.0" }
 crc32fast = { version = "1.3.2", features = ["nightly"] }
-divan = "0.1.2"
+divan = "0.1.3"
 sha1 = "0.10.6"
 sha2 = "0.10.8"
 

--- a/benches/checksums.rs
+++ b/benches/checksums.rs
@@ -1,4 +1,5 @@
 use blake2::digest::{typenum::U4, Digest};
+use divan::{counter::BytesCount, Bencher};
 
 fn main() {
     // Run registered benchmarks.
@@ -17,49 +18,67 @@ const LARGE_PAGE: &[u8; 1 << 20] = &{
 };
 
 #[divan::bench(consts = SIZES)]
-fn crc<const N: usize>() -> u32 {
-    crc32fast::hash(&divan::black_box(LARGE_PAGE)[..N])
+fn crc<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crc32fast::hash(&divan::black_box(LARGE_PAGE)[..N]))
 }
 
 #[divan::bench(consts = SIZES)]
-fn adler<const N: usize>() -> u32 {
-    adler::adler32_slice(&divan::black_box(LARGE_PAGE)[..N])
+fn adler<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| adler::adler32_slice(&divan::black_box(LARGE_PAGE)[..N]))
 }
 
 #[divan::bench(consts = SIZES)]
-fn blake2b_32<const N: usize>() -> u32 {
-    crypto::<blake2::Blake2b<U4>, N>()
+fn blake2b_32<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<blake2::Blake2b<U4>, N>())
 }
 
 #[divan::bench(consts = SIZES)]
-fn blake2b_512<const N: usize>() -> u32 {
-    crypto::<blake2::Blake2b512, N>()
+fn blake2b_512<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<blake2::Blake2b512, N>())
 }
 
 #[divan::bench(consts = SIZES)]
-fn blake2s_32<const N: usize>() -> u32 {
-    crypto::<blake2::Blake2s<U4>, N>()
+fn blake2s_32<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<blake2::Blake2s<U4>, N>())
 }
 
 #[divan::bench(consts = SIZES)]
-fn blake2s_256<const N: usize>() -> u32 {
-    crypto::<blake2::Blake2s256, N>()
+fn blake2s_256<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<blake2::Blake2s256, N>())
 }
 
 #[divan::bench(consts = SIZES)]
-fn blake3<const N: usize>() -> u32 {
-    let res = blake3::hash(&divan::black_box(LARGE_PAGE)[..N]);
-    u32::from_ne_bytes(res.as_bytes()[0..4].try_into().unwrap())
+fn blake3<const N: usize>(bencher: Bencher) {
+    bencher.counter(BytesCount::new(N)).bench(|| {
+        let res = blake3::hash(&divan::black_box(LARGE_PAGE)[..N]);
+        u32::from_ne_bytes(res.as_bytes()[0..4].try_into().unwrap())
+    })
 }
 
 #[divan::bench(consts = SIZES)]
-fn sha1<const N: usize>() -> u32 {
-    crypto::<sha1::Sha1, N>()
+fn sha1<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<sha1::Sha1, N>())
 }
 
 #[divan::bench(consts = SIZES)]
-fn sha256<const N: usize>() -> u32 {
-    crypto::<sha2::Sha256, N>()
+fn sha256<const N: usize>(bencher: Bencher) {
+    bencher
+        .counter(BytesCount::new(N))
+        .bench(|| crypto::<sha2::Sha256, N>())
 }
 
 fn crypto<D: Digest, const N: usize>() -> u32 {


### PR DESCRIPTION
Use [`BytesCount`](https://docs.rs/divan/latest/divan/counter/struct.BytesCount.html) to output the checksum algorithm throughput.

<details>
<summary>Example output for Apple Macbook Pro M2 Max (<code>aarch64-apple-darwin</code>)</summary>

```txt
checksums       fastest    │ slowest    │ median     │ mean       │ samples │ iters
├─ adler                   │            │            │            │         │
│  ├─ 4096      681.9 ns   │ 702.8 ns   │ 687.1 ns   │ 687.4 ns   │ 100     │ 800
│  │            6.006 GB/s │ 5.828 GB/s │ 5.96 GB/s  │ 5.958 GB/s │         │
│  ├─ 16384     2.687 µs   │ 2.999 µs   │ 2.729 µs   │ 2.76 µs    │ 100     │ 200
│  │            6.097 GB/s │ 5.461 GB/s │ 6.003 GB/s │ 5.934 GB/s │         │
│  ├─ 65536     12.08 µs   │ 14.58 µs   │ 12.24 µs   │ 12.3 µs    │ 100     │ 100
│  │            5.423 GB/s │ 4.494 GB/s │ 5.35 GB/s  │ 5.325 GB/s │         │
│  ╰─ 1048576   197.8 µs   │ 245.3 µs   │ 203.1 µs   │ 204.2 µs   │ 100     │ 100
│               5.3 GB/s   │ 4.274 GB/s │ 5.161 GB/s │ 5.134 GB/s │         │
├─ blake2b_32              │            │            │            │         │
│  ├─ 4096      3.832 µs   │ 8.499 µs   │ 3.874 µs   │ 3.94 µs    │ 100     │ 100
│  │            1.068 GB/s │ 481.9 MB/s │ 1.057 GB/s │ 1.039 GB/s │         │
│  ├─ 16384     15.41 µs   │ 20.7 µs    │ 15.95 µs   │ 15.88 µs   │ 100     │ 100
│  │            1.062 GB/s │ 791.1 MB/s │ 1.026 GB/s │ 1.031 GB/s │         │
│  ├─ 65536     61.66 µs   │ 64.91 µs   │ 61.95 µs   │ 62.64 µs   │ 100     │ 100
│  │            1.062 GB/s │ 1.009 GB/s │ 1.057 GB/s │ 1.046 GB/s │         │
│  ╰─ 1048576   957.9 µs   │ 1.082 ms   │ 990.1 µs   │ 991.3 µs   │ 100     │ 100
│               1.094 GB/s │ 968.9 MB/s │ 1.058 GB/s │ 1.057 GB/s │         │
├─ blake2b_512             │            │            │            │         │
│  ├─ 4096      3.749 µs   │ 3.854 µs   │ 3.812 µs   │ 3.804 µs   │ 100     │ 200
│  │            1.092 GB/s │ 1.062 GB/s │ 1.074 GB/s │ 1.076 GB/s │         │
│  ├─ 16384     15.41 µs   │ 22.16 µs   │ 15.95 µs   │ 15.97 µs   │ 100     │ 100
│  │            1.062 GB/s │ 739.1 MB/s │ 1.026 GB/s │ 1.025 GB/s │         │
│  ├─ 65536     59.87 µs   │ 64.37 µs   │ 62.27 µs   │ 61.88 µs   │ 100     │ 100
│  │            1.094 GB/s │ 1.018 GB/s │ 1.052 GB/s │ 1.059 GB/s │         │
│  ╰─ 1048576   958.1 µs   │ 1.091 ms   │ 995.9 µs   │ 1.004 ms   │ 100     │ 100
│               1.094 GB/s │ 960.3 MB/s │ 1.052 GB/s │ 1.044 GB/s │         │
├─ blake2s_256             │            │            │            │         │
│  ├─ 4096      6.624 µs   │ 10.66 µs   │ 6.749 µs   │ 6.835 µs   │ 100     │ 100
│  │            618.2 MB/s │ 383.9 MB/s │ 606.8 MB/s │ 599.2 MB/s │         │
│  ├─ 16384     26.79 µs   │ 28.95 µs   │ 26.95 µs   │ 26.99 µs   │ 100     │ 100
│  │            611.5 MB/s │ 565.7 MB/s │ 607.7 MB/s │ 606.8 MB/s │         │
│  ├─ 65536     100.9 µs   │ 138.4 µs   │ 107.2 µs   │ 106.1 µs   │ 100     │ 100
│  │            649.1 MB/s │ 473.1 MB/s │ 611.1 MB/s │ 617.6 MB/s │         │
│  ╰─ 1048576   1.612 ms   │ 7.754 ms   │ 1.731 ms   │ 1.996 ms   │ 100     │ 100
│               650.2 MB/s │ 135.2 MB/s │ 605.7 MB/s │ 525.2 MB/s │         │
├─ blake2s_32              │            │            │            │         │
│  ├─ 4096      6.624 µs   │ 166.8 µs   │ 6.832 µs   │ 9.675 µs   │ 100     │ 100
│  │            618.2 MB/s │ 24.55 MB/s │ 599.4 MB/s │ 423.3 MB/s │         │
│  ├─ 16384     26.12 µs   │ 71.29 µs   │ 26.91 µs   │ 27.65 µs   │ 100     │ 100
│  │            627.1 MB/s │ 229.8 MB/s │ 608.6 MB/s │ 592.3 MB/s │         │
│  ├─ 65536     106.2 µs   │ 125 µs     │ 107.3 µs   │ 108.4 µs   │ 100     │ 100
│  │            617 MB/s   │ 524.1 MB/s │ 610.4 MB/s │ 604.5 MB/s │         │
│  ╰─ 1048576   1.692 ms   │ 20.15 ms   │ 1.733 ms   │ 1.982 ms   │ 100     │ 100
│               619.3 MB/s │ 52.01 MB/s │ 604.9 MB/s │ 528.8 MB/s │         │
├─ blake3                  │            │            │            │         │
│  ├─ 4096      2.374 µs   │ 4.915 µs   │ 2.416 µs   │ 2.476 µs   │ 100     │ 100
│  │            1.724 GB/s │ 833.2 MB/s │ 1.694 GB/s │ 1.654 GB/s │         │
│  ├─ 16384     9.082 µs   │ 9.916 µs   │ 9.166 µs   │ 9.219 µs   │ 100     │ 100
│  │            1.803 GB/s │ 1.652 GB/s │ 1.787 GB/s │ 1.777 GB/s │         │
│  ├─ 65536     35.16 µs   │ 74.49 µs   │ 36.43 µs   │ 37.04 µs   │ 100     │ 100
│  │            1.863 GB/s │ 879.6 MB/s │ 1.798 GB/s │ 1.769 GB/s │         │
│  ╰─ 1048576   580.4 µs   │ 1.647 ms   │ 606.1 µs   │ 622.1 µs   │ 100     │ 100
│               1.806 GB/s │ 636.2 MB/s │ 1.729 GB/s │ 1.685 GB/s │         │
├─ crc                     │            │            │            │         │
│  ├─ 4096      476.2 ns   │ 491.8 ns   │ 478.8 ns   │ 479.5 ns   │ 100     │ 1600
│  │            8.6 GB/s   │ 8.327 GB/s │ 8.553 GB/s │ 8.541 GB/s │         │
│  ├─ 16384     1.957 µs   │ 1.999 µs   │ 1.968 µs   │ 1.975 µs   │ 100     │ 400
│  │            8.368 GB/s │ 8.193 GB/s │ 8.323 GB/s │ 8.295 GB/s │         │
│  ├─ 65536     7.54 µs    │ 8.082 µs   │ 7.832 µs   │ 7.752 µs   │ 100     │ 100
│  │            8.69 GB/s  │ 8.108 GB/s │ 8.366 GB/s │ 8.453 GB/s │         │
│  ╰─ 1048576   121.8 µs   │ 191.5 µs   │ 125.6 µs   │ 127 µs     │ 100     │ 100
│               8.606 GB/s │ 5.473 GB/s │ 8.346 GB/s │ 8.252 GB/s │         │
├─ sha1                    │            │            │            │         │
│  ├─ 4096      4.082 µs   │ 5.249 µs   │ 4.124 µs   │ 4.149 µs   │ 100     │ 100
│  │            1.003 GB/s │ 780.2 MB/s │ 993 MB/s   │ 987 MB/s   │         │
│  ├─ 16384     16.2 µs    │ 16.45 µs   │ 16.31 µs   │ 16.32 µs   │ 100     │ 100
│  │            1.01 GB/s  │ 995.4 MB/s │ 1.004 GB/s │ 1.003 GB/s │         │
│  ├─ 65536     64.7 µs    │ 85.74 µs   │ 64.91 µs   │ 65.25 µs   │ 100     │ 100
│  │            1.012 GB/s │ 764.2 MB/s │ 1.009 GB/s │ 1.004 GB/s │         │
│  ╰─ 1048576   1.035 ms   │ 1.263 ms   │ 1.081 ms   │ 1.087 ms   │ 100     │ 100
│               1.012 GB/s │ 830.1 MB/s │ 969.8 MB/s │ 963.8 MB/s │         │
╰─ sha256                  │            │            │            │         │
   ├─ 4096      12.33 µs   │ 15.91 µs   │ 12.45 µs   │ 12.81 µs   │ 100     │ 100
   │            332.1 MB/s │ 257.3 MB/s │ 328.7 MB/s │ 319.5 MB/s │         │
   ├─ 16384     47.49 µs   │ 57.08 µs   │ 48.89 µs   │ 48.75 µs   │ 100     │ 100
   │            344.9 MB/s │ 287 MB/s   │ 335 MB/s   │ 336 MB/s   │         │
   ├─ 65536     195.3 µs   │ 217.9 µs   │ 195.7 µs   │ 198.3 µs   │ 100     │ 100
   │            335.4 MB/s │ 300.7 MB/s │ 334.8 MB/s │ 330.3 MB/s │         │
   ╰─ 1048576   3.035 ms   │ 11.51 ms   │ 3.135 ms   │ 3.234 ms   │ 100     │ 100
                345.4 MB/s │ 91.09 MB/s │ 334.3 MB/s │ 324.1 MB/s │         │
```
</details>
