### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,21 +212,23 @@ dependencies = [
 
 [[package]]
 name = "divan"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f0b89afd851ac3372f22144e66157058999ffe695a337711d5511acb91504"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
+ "cfg-if",
  "clap",
  "condtype",
  "divan-macros",
+ "libc",
  "regex-lite",
 ]
 
 [[package]]
 name = "divan-macros"
-version = "0.1.3"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016a705a288faf1e8d45113e54ffcc7b566e1572ff829b8455546362b0c902f5"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 [dev-dependencies]
-divan = "0.1.3"
+divan = "0.1.11"
 
 adler = "1.0.2"
 blake2 = { version = "0.10.6" }

--- a/benches/checksums.rs
+++ b/benches/checksums.rs
@@ -19,9 +19,10 @@ macro_rules! bench {
         $(
             #[divan::bench(args = crate::SIZES)]
             fn $func_name(bencher: divan::Bencher, n: usize) {
+                let slice = divan::black_box(&crate::LARGE_PAGE[..n]);
                 bencher
                     .counter(divan::counter::BytesCount::new(n))
-                    .bench(|| ($func)(&divan::black_box(crate::LARGE_PAGE)[..n]))
+                    .bench(|| $func(slice))
             }
         )*
     };

--- a/benches/checksums.rs
+++ b/benches/checksums.rs
@@ -17,11 +17,11 @@ const LARGE_PAGE: &[u8; 1 << 20] = &{
 macro_rules! bench {
     ($($func_name:ident => $func:expr;)*) => {
         $(
-            #[divan::bench(consts = crate::SIZES)]
-            fn $func_name<const N: usize>(bencher: divan::Bencher) {
+            #[divan::bench(args = crate::SIZES)]
+            fn $func_name(bencher: divan::Bencher, n: usize) {
                 bencher
-                    .counter(divan::counter::BytesCount::new(N))
-                    .bench(|| ($func)(&divan::black_box(crate::LARGE_PAGE)[..N]))
+                    .counter(divan::counter::BytesCount::new(n))
+                    .bench(|| ($func)(&divan::black_box(crate::LARGE_PAGE)[..n]))
             }
         )*
     };


### PR DESCRIPTION
The new [`args`](https://docs.rs/divan/latest/divan/attr.bench.html#args) option greatly reduces compile times and is not limited to arrays/slices.